### PR TITLE
4.8 Использование виджетов с установкой размеров

### DIFF
--- a/lib/ui/images/loading_progress_value.dart
+++ b/lib/ui/images/loading_progress_value.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/painting.dart';
+
+class LoadingProgressValue {
+  final double? value;
+
+  const LoadingProgressValue({this.value});
+
+  factory LoadingProgressValue.fromImageChunkEvent(ImageChunkEvent loadingProgress) {
+    final expectedTotalBytes = loadingProgress.expectedTotalBytes;
+
+    if (expectedTotalBytes != null && expectedTotalBytes > 0) {
+      return LoadingProgressValue(value: loadingProgress.cumulativeBytesLoaded / expectedTotalBytes);
+    }
+
+    return const LoadingProgressValue();
+  }
+}

--- a/lib/ui/sight/sight_details/widgets/sight_details_header.dart
+++ b/lib/ui/sight/sight_details/widgets/sight_details_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:places/assets/theme/colors.dart';
 import 'package:places/domain/sight/sight.dart';
+import 'package:places/ui/images/loading_progress_value.dart';
 
 class SightDetailsHeader extends StatelessWidget {
   final Sight sight;
@@ -16,6 +17,21 @@ class SightDetailsHeader extends StatelessWidget {
       child: SizedBox.expand(
         child: Stack(
           children: [
+            SizedBox.expand(
+              child: Image.network(
+                sight.imageUrl,
+                fit: BoxFit.cover,
+                loadingBuilder: (context, child, loadingProgress) {
+                  return loadingProgress == null
+                      ? child
+                      : Center(
+                          child: CircularProgressIndicator(
+                            value: LoadingProgressValue.fromImageChunkEvent(loadingProgress).value,
+                          ),
+                        );
+                },
+              ),
+            ),
             Positioned(
               top: 36,
               left: 16,

--- a/lib/ui/sight/sight_list/sight_list_page.dart
+++ b/lib/ui/sight/sight_list/sight_list_page.dart
@@ -24,11 +24,7 @@ class _SightListPageState extends State<SightListPage> {
                 .map(
                   (sight) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
-                    child: SizedBox(
-                      height: 188,
-                      width: double.infinity,
-                      child: SightCard(sight: sight),
-                    ),
+                    child: SightCard(sight: sight),
                   ),
                 )
                 .toList(),

--- a/lib/ui/sight/sight_list/widgets/sight_card.dart
+++ b/lib/ui/sight/sight_list/widgets/sight_card.dart
@@ -18,7 +18,8 @@ class SightCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(
+          Flexible(
+            flex: 3,
             child: SizedBox(
               width: double.infinity,
               child: DecoratedBox(
@@ -57,27 +58,36 @@ class SightCard extends StatelessWidget {
               ),
             ),
           ),
-          Expanded(
+          Flexible(
+            flex: 2,
             child: Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  const SizedBox(height: 16),
                   Text(
                     sight.name,
                     style: const AppTextStyle(
                       color: AppColors.secondary,
                     ),
-                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  Text(
-                    sight.details,
-                    style: const AppSmallStyle(
-                      color: AppColors.secondary2,
-                    ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      return ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxWidth: constraints.maxWidth / 2,
+                        ),
+                        child: Text(
+                          sight.details,
+                          style: const AppSmallStyle(
+                            color: AppColors.secondary2,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/lib/ui/sight/sight_list/widgets/sight_card.dart
+++ b/lib/ui/sight/sight_list/widgets/sight_card.dart
@@ -11,23 +11,30 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.0),
-      ),
-      color: AppColors.background,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Flexible(
-            flex: 3,
-            child: _SightCardHeader(sight: sight),
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 188, maxWidth: 328),
+      child: Card(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        color: AppColors.background,
+        child: AspectRatio(
+          aspectRatio: 3 / 2,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                flex: 3,
+                child: _SightCardHeader(sight: sight),
+              ),
+              Flexible(
+                flex: 2,
+                child: _SightCardBody(sight: sight),
+              ),
+            ],
           ),
-          Flexible(
-            flex: 2,
-            child: _SightCardBody(sight: sight),
-          ),
-        ],
+        ),
       ),
     );
   }
@@ -94,21 +101,12 @@ class _SightCardBody extends StatelessWidget {
             ),
             overflow: TextOverflow.ellipsis,
           ),
-          LayoutBuilder(
-            builder: (context, constraints) {
-              return ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxWidth: constraints.maxWidth / 2,
-                ),
-                child: Text(
-                  sight.details,
-                  style: const AppSmallStyle(
-                    color: AppColors.secondary2,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              );
-            },
+          Text(
+            sight.details,
+            style: const AppSmallStyle(
+              color: AppColors.secondary2,
+            ),
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/lib/ui/sight/sight_list/widgets/sight_card.dart
+++ b/lib/ui/sight/sight_list/widgets/sight_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/assets/theme/colors.dart';
 import 'package:places/assets/theme/typography.dart';
 import 'package:places/domain/sight/sight.dart';
+import 'package:places/ui/images/loading_progress_value.dart';
 
 class SightCard extends StatelessWidget {
   final Sight sight;
@@ -20,81 +21,123 @@ class SightCard extends StatelessWidget {
         children: [
           Flexible(
             flex: 3,
-            child: SizedBox(
-              width: double.infinity,
-              child: DecoratedBox(
-                decoration: const BoxDecoration(
-                  color: AppColors.placeholder,
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            sight.type.title,
-                            style: const AppSmallBoldStyle(
-                              color: AppColors.white,
-                            ),
-                          ),
-                          const Padding(
-                            padding: EdgeInsets.only(top: 3, right: 2),
-                            child: ColoredBox(
-                              color: AppColors.white,
-                              child: SizedBox.square(
-                                dimension: 20,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+            child: _SightCardHeader(sight: sight),
           ),
           Flexible(
             flex: 2,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 16),
-                  Text(
-                    sight.name,
-                    style: const AppTextStyle(
-                      color: AppColors.secondary,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  LayoutBuilder(
-                    builder: (context, constraints) {
-                      return ConstrainedBox(
-                        constraints: BoxConstraints(
-                          maxWidth: constraints.maxWidth / 2,
-                        ),
-                        child: Text(
-                          sight.details,
-                          style: const AppSmallStyle(
-                            color: AppColors.secondary2,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      );
-                    },
-                  ),
-                ],
-              ),
-            ),
+            child: _SightCardBody(sight: sight),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _SightCardHeader extends StatelessWidget {
+  final Sight sight;
+
+  const _SightCardHeader({required this.sight, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        SizedBox(
+          width: double.infinity,
+          child: _SightImage(imageUrl: sight.imageUrl),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                sight.type.title,
+                style: const AppSmallBoldStyle(
+                  color: AppColors.white,
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.only(top: 3, right: 2),
+                child: ColoredBox(
+                  color: AppColors.white,
+                  child: SizedBox.square(
+                    dimension: 20,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SightCardBody extends StatelessWidget {
+  final Sight sight;
+
+  const _SightCardBody({required this.sight, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 16),
+          Text(
+            sight.name,
+            style: const AppTextStyle(
+              color: AppColors.secondary,
+            ),
+            overflow: TextOverflow.ellipsis,
+          ),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              return ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: constraints.maxWidth / 2,
+                ),
+                child: Text(
+                  sight.details,
+                  style: const AppSmallStyle(
+                    color: AppColors.secondary2,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SightImage extends StatelessWidget {
+  final String imageUrl;
+
+  const _SightImage({required this.imageUrl, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      imageUrl,
+      fit: BoxFit.fitWidth,
+      loadingBuilder: (context, child, loadingProgress) {
+        return loadingProgress == null
+            ? ClipRRect(
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                child: child,
+              )
+            : Center(
+                child: CircularProgressIndicator(
+                  value: LoadingProgressValue.fromImageChunkEvent(loadingProgress).value,
+                ),
+              );
+      },
     );
   }
 }


### PR DESCRIPTION
Переверстать AppBar через наследника PreferredSizeWidget. - сделано ранее

В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся?

ConstrainedBox только накладывает дополнительные ограничения к тем, что получены от своего родителя.
В данном случае SightCard приводит ConstrainedBox к своему размеру, поэтому дочерний  Text также получит размеры SightCard, игнорируя полученные ограничения, и займет всю доступную область

<img width="416" alt="image" src="https://user-images.githubusercontent.com/47079939/212039848-c21fc79b-d9aa-4647-9cb7-2998713e3839.png">


<img width="430" alt="image" src="https://user-images.githubusercontent.com/47079939/212045290-15a87446-ebae-4033-89ed-cfea5ac132ed.png">

